### PR TITLE
#63: update PHP packages to 8.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,7 @@ RUN apt-get -y install ruby-dev libmagic-dev zlib1g-dev openssl \
 # PHP
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
   && apt-get update -y --fix-missing \
-  && apt-get -y install php7.2 php-pear php7.2-curl php7.2-dev php7.2-gd php7.2-mbstring php7.2-zip php7.2-mysql php7.2-xml \
+  && apt-get -y install php8.2 php-pear php8.2-curl php8.2-dev php8.2-gd php8.2-mbstring php8.2-zip php8.2-mysql php8.2-xml \
   && curl --silent --show-error https://getcomposer.org/installer | php \
   && mv composer.phar /usr/local/bin/composer \
   && bash -c 'php --version'


### PR DESCRIPTION
Fixes #63.

## Summary
- Replaces the default image PHP package set from PHP 7.2 to PHP 8.2.
- Keeps the existing Ondrej PPA flow and Composer installation unchanged.

## Validation
- `git diff --check`
- `git diff -- Dockerfile | gitleaks stdin --no-banner --redact --exit-code 1`
- `sudo docker run --rm ubuntu:22.04 bash -lc 'set -euxo pipefail; export DEBIAN_FRONTEND=noninteractive LC_ALL=C.UTF-8; apt-get update -y --fix-missing; apt-get -y --no-install-recommends install software-properties-common ca-certificates curl gnupg2 locales; locale-gen en_US.UTF-8 || true; add-apt-repository -y ppa:ondrej/php; apt-get update -y --fix-missing; apt-get -y install php8.2 php-pear php8.2-curl php8.2-dev php8.2-gd php8.2-mbstring php8.2-zip php8.2-mysql php8.2-xml; php --version'`
  - observed `PHP 8.2.31 (cli)`
- `hadolint --config .hadolint.yaml --failure-threshold error Dockerfile` via Dockerized hadolint on Kali; existing non-error findings only, exit 0.

No secrets or credentials are included.
