### PR TITLE
Update PHP packages to 8.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN apt-get -y --no-install-recommends install wget \
   software-properties-common
 
 # LaTeX
-ENV TEXLIVE_YEAR 2025
+ENV TEXLIVE_YEAR 2026
 RUN mkdir /tmp/texlive \
   && cd /tmp/texlive \
   && wget --quiet http://mirror.ctan.org/systems/texlive/tlnet/install-tl.zip \
@@ -118,7 +118,7 @@ RUN apt-get -y install ruby-dev libmagic-dev zlib1g-dev openssl \
 # PHP
 RUN LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
   && apt-get update -y --fix-missing \
-  && apt-get -y install php7.2 php-pear php7.2-curl php7.2-dev php7.2-gd php7.2-mbstring php7.2-zip php7.2-mysql php7.2-xml \
+  && apt-get -y install php8.2 php-pear php8.2-curl php8.2-dev php8.2-gd php8.2-mbstring php8.2-zip php8.2-mysql php8.2-xml \
   && curl --silent --show-error https://getcomposer.org/installer | php \
   && mv composer.phar /usr/local/bin/composer \
   && bash -c 'php --version'
@@ -170,7 +170,7 @@ RUN echo 'export PATH=${PATH}:/usr/lib/postgresql/14/bin' >> /root/.profile \
 ENV MAVEN_VERSION 3.9.12
 ENV M2_HOME "/usr/local/apache-maven/apache-maven-${MAVEN_VERSION}"
 RUN echo 'export M2_HOME=/usr/local/apache-maven/apache-maven-${MAVEN_VERSION}' >> /root/.profile \
-  && wget --quiet "https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" \
+  && wget --quiet "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" \
   && mkdir -p /usr/local/apache-maven \
   && mv "apache-maven-${MAVEN_VERSION}-bin.tar.gz" /usr/local/apache-maven \
   && tar xzvf "/usr/local/apache-maven/apache-maven-${MAVEN_VERSION}-bin.tar.gz" -C /usr/local/apache-maven/ \


### PR DESCRIPTION
Closes #63.

This updates the Dockerfile PHP package set from PHP 7.2 to PHP 8.2, including the matching curl/dev/gd/mbstring/zip/mysql/xml extension packages.

While validating the full image build, two current build pins had to be refreshed so the Dockerfile can still build far enough to validate PHP:

- `TEXLIVE_YEAR` is now `2026`, matching the current TeX Live installer output.
- Maven 3.9.12 is downloaded from `archive.apache.org`; the old `dlcdn.apache.org` URL now returns 404 for that archived release.

Validation:

- `docker build . -t rultor-image-63 --progress=plain`
- `docker run --rm rultor-image-63 'php --version && composer --version && php -m | grep -E "^(curl|gd|mbstring|mysqli|mysqlnd|PDO|pdo_mysql|xml|zip)$" | sort && mvn -version | head -n 1 && pdflatex --version | head -n 1'`
  - PHP 8.2.31
  - Composer 2.9.8
  - PHP modules: PDO, curl, gd, mbstring, mysqli, mysqlnd, pdo_mysql, xml, zip
  - Apache Maven 3.9.12
  - pdfTeX / TeX Live 2026
- `git diff --check`
- `git diff --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1`
- `docker run --rm -i hadolint/hadolint:v2.14.0-alpine hadolint --failure-threshold error - < Dockerfile`
